### PR TITLE
feat: optimize curFirstSyncCall

### DIFF
--- a/base_atomos.go
+++ b/base_atomos.go
@@ -364,7 +364,6 @@ func (a *BaseAtomos) syncGetFirstSyncCallName(callerID SelfID) (string, bool, *E
 	if ba == nil {
 		return "", false, NewErrorf(ErrFrameworkInternalError, "IDFirstSyncCall: BaseAtomos is nil.").AddStack(nil)
 	}
-	info := ba.id
 
 	// 远程调用
 	// 如果调用ID的Go ID为0，证明远程调用，直接返回当前的FirstSyncCall即可。
@@ -372,10 +371,8 @@ func (a *BaseAtomos) syncGetFirstSyncCallName(callerID SelfID) (string, bool, *E
 		if firstSyncCall = callerID.getCurFirstSyncCall(); firstSyncCall == "" {
 			return "", false, NewErrorf(ErrFrameworkInternalError, "IDFirstSyncCall: callerID is invalid. callerID=(%v)", callerID).AddStack(nil)
 		}
-		if ba == nil {
-			return "", false, NewErrorf(ErrFrameworkInternalError, "IDFirstSyncCall: BaseAtomos or fsc is nil. info=(%v),callerID=(%v)", info, callerID).AddStack(nil)
-		}
-		if ba.fsc.curFirstSyncCall == firstSyncCall {
+		curFirstSyncCall := ba.fsc.getCurFirstSyncCall()
+		if curFirstSyncCall == firstSyncCall {
 			return "", false, NewErrorf(ErrIDFirstSyncCallDeadlock, "IDFirstSyncCall: Call chain deadlock. callerID=(%v)", callerID).AddStack(nil)
 		}
 		return firstSyncCall, false, nil

--- a/simulate_test.go
+++ b/simulate_test.go
@@ -189,7 +189,7 @@ func newTestFakeElement(t *testing.T, process *CosmosProcess, autoData bool) *El
 				selfAtomLocal := selfAtom.(*AtomLocal)
 				defer selfAtomTracker.Release()
 				selfAtom.AsyncMessagingByName(selfAtomLocal, "testMessage", 0, &String{S: "in"}, func(out proto.Message, err *Error) {
-					if selfAtomLocal.atomos.fsc.curFirstSyncCall == "" {
+					if selfAtomLocal.atomos.fsc.getCurFirstSyncCall() == "" {
 						selfAtomLocal.Log().Error("testingLocalAsyncSelfFirstSyncCall: curFirstSyncCall is empty")
 						return
 					}
@@ -234,7 +234,7 @@ func newTestFakeElement(t *testing.T, process *CosmosProcess, autoData bool) *El
 				}
 
 				selfAtom.AsyncMessagingByName(selfAtomLocal, "testMessage", 0, &String{S: "in"}, func(out proto.Message, err *Error) {
-					if selfAtomLocal.atomos.fsc.curFirstSyncCall == "" {
+					if selfAtomLocal.atomos.fsc.getCurFirstSyncCall() == "" {
 						selfAtomLocal.Log().Error("testingLocalSyncAndAsyncOtherFirstSyncCall: curFirstSyncCall is empty")
 						return
 					}
@@ -259,7 +259,7 @@ func newTestFakeElement(t *testing.T, process *CosmosProcess, autoData bool) *El
 				}
 
 				selfAtom.AsyncMessagingByName(selfAtomLocal, "testMessage", 0, &String{S: "in"}, func(out proto.Message, err *Error) {
-					if selfAtomLocal.atomos.fsc.curFirstSyncCall == "" {
+					if selfAtomLocal.atomos.fsc.getCurFirstSyncCall() == "" {
 						selfAtomLocal.Log().Error("testingLocalSyncAndAsyncOtherFirstSyncCall: curFirstSyncCall is empty")
 						return
 					}
@@ -327,7 +327,7 @@ func newTestFakeElement(t *testing.T, process *CosmosProcess, autoData bool) *El
 				defer otherAtomTracker.Release()
 
 				otherAtomLocal.AsyncMessagingByName(selfAtomLocal, "testingUtilLocalSyncChain", 0, in, func(out proto.Message, err *Error) {
-					if selfAtomLocal.atomos.fsc.curFirstSyncCall == "" {
+					if selfAtomLocal.atomos.fsc.getCurFirstSyncCall() == "" {
 						selfAtomLocal.Log().Error("testingLocalAsyncChainSelfFirstSyncCall: curFirstSyncCall is empty")
 						return
 					}
@@ -372,7 +372,7 @@ func newTestFakeElement(t *testing.T, process *CosmosProcess, autoData bool) *El
 						selfAtomLocal.Log().Error("testingLocalSyncChainSelfFirstSyncCallDeadlock: taskID not match")
 						return
 					}
-					if selfAtomLocal.atomos.fsc.curFirstSyncCall != "" {
+					if selfAtomLocal.atomos.fsc.getCurFirstSyncCall() != "" {
 						selfAtomLocal.Log().Error("testingLocalSyncChainSelfFirstSyncCallDeadlock: curFirstSyncCall is empty")
 						return
 					}


### PR DESCRIPTION
背景：if ba.fsc.curFirstSyncCall == firstSyncCall 会报错空指针，经测试，取值没有问题，取值之后比较有问题。触发概率很小。有一段时间是 query user info 触发；后面都是 update user info 触发。

解决：怀疑存在 curFirstSyncCall 并发读写，导致 ba.fsc.curFirstSyncCall 取的不完整的长度和指针。将这个变量的全部读写都加上并发保护，同时将互斥锁优化为 atomic。